### PR TITLE
feat(requests): настроить отправку уведомлений при создании и обновлении заявки #124

### DIFF
--- a/backend/src/notification/notification.module.ts
+++ b/backend/src/notification/notification.module.ts
@@ -9,5 +9,6 @@ import { wsConfig } from '../config/ws.config';
 @Module({
   imports: [ConfigModule.forFeature(wsConfig), AuthModule, UsersModule],
   providers: [NotificationsGateway, WsJwtGuard],
+  exports: [NotificationsGateway],
 })
 export class NotificationModule {}

--- a/backend/src/requests/requests.module.ts
+++ b/backend/src/requests/requests.module.ts
@@ -5,9 +5,13 @@ import { RequestsController } from './requests.controller';
 import { Request } from './entities/request.entity';
 import { Skill } from '../skills/entities/skill.entity';
 import { User } from '../users/entities/user.entity';
+import { NotificationModule } from '../notification/notification.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Request, User, Skill])],
+  imports: [
+    TypeOrmModule.forFeature([Request, User, Skill]),
+    NotificationModule,
+  ],
   controllers: [RequestsController],
   providers: [RequestsService],
   exports: [RequestsService],

--- a/backend/src/requests/requests.service.ts
+++ b/backend/src/requests/requests.service.ts
@@ -3,6 +3,7 @@ import {
   NotFoundException,
   ForbiddenException,
   BadRequestException,
+  InternalServerErrorException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
@@ -13,6 +14,8 @@ import { RequestStatus } from './request-status.enum';
 import { User } from '../users/entities/user.entity';
 import { Skill } from '../skills/entities/skill.entity';
 import { plainToInstance } from 'class-transformer';
+import { NotificationsGateway } from '../notification/notifications.gateway';
+import { NotificationPayload } from '../notification/guards/ws-types';
 
 @Injectable()
 export class RequestsService {
@@ -23,6 +26,7 @@ export class RequestsService {
     private usersRepository: Repository<User>,
     @InjectRepository(Skill)
     private skillsRepository: Repository<Skill>,
+    private notificationsGateway: NotificationsGateway,
   ) {}
 
   // Проверка прав пользователя на заявку
@@ -130,7 +134,25 @@ export class RequestsService {
     });
 
     // Сохранение в БД и возврат результата
-    return await this.requestsRepository.save(request);
+    // return await this.requestsRepository.save(request);
+    const savedRequests = await this.requestsRepository.save(request);
+
+    // Загружаем имя отправителя по senderId
+    const sender = await this.usersRepository.findOneBy({ id: senderId });
+    if (!sender) {
+      throw new InternalServerErrorException(
+        'Отправитель не найден при отправке уведомления',
+      );
+    }
+
+    this.sendNotification(
+      receiverId,
+      'new_request',
+      sender.name,
+      offeredSkill.title,
+    );
+
+    return savedRequests;
   }
 
   // Получить входящие заявки
@@ -211,7 +233,33 @@ export class RequestsService {
     request.status = RequestStatus.ACCEPTED;
     request.isRead = true;
 
-    return await this.requestsRepository.save(request);
+    // return await this.requestsRepository.save(request);
+    const savedRequests = await this.requestsRepository.save(request);
+
+    const receiver = await this.usersRepository.findOneBy({ id: userId });
+    const offeredSkill = await this.skillsRepository.findOneBy({
+      id: request.offeredSkillId,
+    });
+
+    if (!receiver) {
+      throw new InternalServerErrorException(
+        'Получатель не найден при отправке уведомления об одобрении заявки',
+      );
+    }
+    if (!offeredSkill) {
+      throw new InternalServerErrorException(
+        'Навык не найден при отправке уведомления об одобрении заявки',
+      );
+    }
+
+    this.sendNotification(
+      request.senderId,
+      'request_accepted',
+      receiver.name,
+      offeredSkill.title,
+    );
+
+    return savedRequests;
   }
 
   // Отклонить заявку
@@ -235,7 +283,33 @@ export class RequestsService {
     request.status = RequestStatus.REJECTED;
     request.isRead = true;
 
-    return await this.requestsRepository.save(request);
+    // return await this.requestsRepository.save(request);
+    const savedRequests = await this.requestsRepository.save(request);
+
+    const receiver = await this.usersRepository.findOneBy({ id: userId });
+    const offeredSkill = await this.skillsRepository.findOneBy({
+      id: request.offeredSkillId,
+    });
+
+    if (!receiver) {
+      throw new InternalServerErrorException(
+        'Получатель не найден при отправке уведомления об отклонении заявки',
+      );
+    }
+    if (!offeredSkill) {
+      throw new InternalServerErrorException(
+        'Навык не найден при отправке уведомления об отклонении заявки',
+      );
+    }
+
+    this.sendNotification(
+      request.senderId,
+      'request_rejected',
+      receiver.name,
+      offeredSkill.title,
+    );
+
+    return savedRequests;
   }
 
   // Удалить заявку
@@ -294,5 +368,24 @@ export class RequestsService {
     }
 
     return await this.requestsRepository.save(request);
+  }
+
+  /**
+   * Отправляет уведомление о заявке указанному пользователю.
+   */
+  private sendNotification(
+    toUserId: string,
+    type: NotificationPayload['type'],
+    fromUserName: string,
+    skillTitle: string,
+  ): void {
+    const payload: NotificationPayload = {
+      type,
+      fromUser: fromUserName,
+      skillName: skillTitle,
+      timestamp: new Date(),
+    };
+
+    this.notificationsGateway.notifyUser(toUserId, payload);
   }
 }


### PR DESCRIPTION
- внедрён NotificationsGateway в RequestsService
- добавлен приватный метод sendNotification для отправки payload
- при создании заявки — уведомление получателю (new_request)
- при принятии — уведомление отправителю (request_accepted)
- при отклонении — уведомление отправителю (request_rejected)
- ошибки целостности обрабатываются через InternalServerErrorException